### PR TITLE
chore: add missing babel preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
+        "@babel/preset-env": "^7.27.2",
         "@babel/preset-flow": "^7.27.1",
         "@babel/preset-react": "^7.27.1",
         "@react-native-community/cli": "latest"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@babel/preset-env": "^7.27.2",
     "@babel/preset-flow": "^7.27.1",
     "@babel/preset-react": "^7.27.1",
     "@react-native-community/cli": "latest"


### PR DESCRIPTION
## Summary
- add `@babel/preset-env` to dev dependencies to satisfy Metro bundler

## Testing
- `npm install --save-dev @babel/preset-env` (failed: 403 Forbidden)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68964c9aaae0832086fcbe17baddd4b6