### PR TITLE
Use Expo Babel preset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": [
-    "@babel/preset-env",
-    "@babel/preset-react",
-    "@babel/preset-flow"
-  ],
-  "plugins": []
-}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+# Babel
+.babelrc

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = function (api) {
+  api.cache(true);
+  return { presets: ['babel-preset-expo'] };
+};


### PR DESCRIPTION
## Summary
- remove legacy `.babelrc` and add `babel.config.js` with Expo preset
- ignore `.babelrc` going forward

## Testing
- `npx expo start --offline`


------
https://chatgpt.com/codex/tasks/task_e_68965394144c8320965a05a187d2a6ac