### PR TITLE
feat: integrate react-native-worklets

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,7 @@
 module.exports = function (api) {
   api.cache(true);
-  return { presets: ['babel-preset-expo'] };
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-worklets/plugin'],
+  };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react-native-gesture-handler": "^2.28.0",
         "react-native-reanimated": "^4.0.1",
         "react-native-safe-area-context": "^5.5.2",
-        "react-native-screens": "^4.13.1"
+        "react-native-screens": "^4.13.1",
+        "react-native-worklets": "^0.4.1"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-native-gesture-handler": "^2.28.0",
     "react-native-reanimated": "^4.0.1",
     "react-native-safe-area-context": "^5.5.2",
-    "react-native-screens": "^4.13.1"
+    "react-native-screens": "^4.13.1",
+    "react-native-worklets": "^0.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- add `react-native-worklets` dependency
- configure Babel to load `react-native-worklets/plugin`

## Testing
- `npx expo start --offline`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689659877a2c83209924503b8c680a2d