### PR TITLE
Configure asset registry for Metro

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,8 +1,17 @@
-// metro.config.js
-module.exports = {
-  transformer: {
-    // Puedes habilitar o deshabilitar la configuración TurboModules aquí si es necesario
-    experimentalImportSupport: true,
-    inlineRequires: false,
-  },
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+// Puedes habilitar o deshabilitar la configuración TurboModules aquí si es necesario
+config.transformer = {
+  ...config.transformer,
+  experimentalImportSupport: true,
+  inlineRequires: false,
 };
+
+config.resolver.assetRegistryPath = require.resolve(
+  'react-native/Libraries/Image/AssetRegistry'
+);
+
+module.exports = config;
+


### PR DESCRIPTION
## Summary
- use Expo's default Metro config
- set `resolver.assetRegistryPath` for React Native images

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68965fa1e1b88320ac1629503c3159cc